### PR TITLE
Add a sync verbose option.

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -11,7 +11,7 @@ import (
 )
 
 var cmdSync = &Command{
-	UsageLine: "sync [import path]",
+	UsageLine: "sync [-v] [import path]",
 	Short:     "sync current GOPATH with GLOCKFILE in the import path's root.",
 	Long: `sync checks the GOPATH for consistency with the given package's GLOCKFILE
 
@@ -25,6 +25,7 @@ Commands are built if necessary.
 
 Options:
 
+        -v	print verbose output
 	-n	read GLOCKFILE from stdin
 
 `,
@@ -32,6 +33,7 @@ Options:
 
 var (
 	syncColor = cmdSync.Flag.Bool("color", true, "if true, colorize terminal output")
+	verbose   = cmdSync.Flag.Bool("v", false, "if true, print verbose output")
 	syncN     = cmdSync.Flag.Bool("n", false, "Read GLOCKFILE from stdin")
 
 	info     = gocolorize.NewColor("green").Paint
@@ -100,6 +102,13 @@ func runSync(cmd *Command, args []string) {
 		default:
 			fmt.Println("[" + info("OK") + "]")
 		}
+		if *verbose {
+			trimmed := bytes.TrimSpace(installOutput)
+			if 0 < len(trimmed) {
+				fmt.Println(string(trimmed))
+			}
+		}
+
 	}
 }
 


### PR DESCRIPTION
This adds a verbose option to the sync cmd, which prints the contents of any install errors.

For example:

```bash
$ glock sync my/repo
cmd github.com/golang/tools/cmd/vet                            	[error exit status 2]

$ glock sync -v my/repo
cmd github.com/golang/tools/cmd/vet                            	[error exit status 2]
github.com/golang/tools/cmd/vet
# github.com/golang/tools/cmd/vet
/home/vagrant/code/datadog/go/src/github.com/golang/tools/cmd/vet/bool.go:167: undefined: astutil.Unparen
```
It looks like the `syncPkg` errors are already well-covered so I didn't add anything there, but if you think there's something to add, I can. Another option is to always print the actual error contents, since you'd pretty much always want to see them.