### PR TITLE
Add support for multiple GOPATH workspaces

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -152,7 +152,7 @@ func truncate(rev string) string {
 }
 
 func syncPkg(ch chan<- string, importPath, expectedRevision, getOutput string, getErr error) {
-	var importDir = filepath.Join(gopath(), "src", importPath)
+	var importDir = filepath.Join(gopaths()[0], "src", importPath)
 	var status bytes.Buffer
 	defer func() { ch <- status.String() }()
 
@@ -177,11 +177,12 @@ func syncPkg(ch chan<- string, importPath, expectedRevision, getOutput string, g
 		maybeGot = warning("get ")
 	}
 
-	actualRevision, err := repo.vcs.head(filepath.Join(gopath(), "src", repo.root), repo.repo)
+	actualRevision, err := repo.vcs.head(repo.path, repo.repo)
 	if err != nil {
 		fmt.Fprintln(&status, "error determining revision of", repo.root, err)
 		perror(err)
 	}
+
 	actualRevision = truncate(actualRevision)
 	fmt.Fprintf(&status, "%-50.49s %-12.12s\t", importPath, actualRevision)
 	if expectedRevision == actualRevision {

--- a/vcs.go
+++ b/vcs.go
@@ -344,13 +344,16 @@ func vcsForDir(p *build.Package) (vcs *vcsCmd, root string, err error) {
 	return nil, "", fmt.Errorf("directory %q is not using a known version control system", origDir)
 }
 
-// repoRoot represents a version control system, a repo, and a root of
-// where to put it on disk.
+// repoRoot represents a version control system, a repo, a path, and a root
+// that is the import path
 type repoRoot struct {
 	vcs *vcsCmd
 
 	// repo is the repository URL, including scheme
 	repo string
+
+	// path is the path of where the repo is to be found on disk
+	path string
 
 	// root is the import path corresponding to the root of the
 	// repository


### PR DESCRIPTION
This PR adds the necessary changes to support users with multiple
`GOPATH` workspaces. Previously the `gopath()` function would truncate
the system `GOPATH` list to only operate on the first value, as a result
of this packages installed in other `GOPATH` workspaces were not
recognized. An attempt was made to try `go get ..` again, this of course
would not function as glock expected given the go tool chain already
recognizes the packages being present in the other workspaces.
Additionally if a project managed by glock is not placed under the
primary workspace the `GLOCKFILE` is not found (given it's looking only
within the primary workspace).

Concisely the changes here address both these issues, we look for the
`GLOCKFILE` in every workspace and look for existing dependencies in the
other workspaces as well.
We also retain the default go tool chain behavior downloading new packages
into the primary workspace (see occurrences of `gopaths()[0]`) all the
while preserving backwards compatibility, single workspace environments
should be completely unaffected by these changes.

@robfig.