### PR TITLE
sync: try checking out the desired revision before running a download…

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -192,6 +192,14 @@ func syncPkg(ch chan<- string, importPath, expectedRevision, getOutput string, g
 
 	fmt.Fprintln(&status, "["+maybeGot+warning(fmt.Sprintf("checkout %-12.12s", expectedRevision))+"]")
 
+	// Checkout the expected revision.  Don't use tagSync because it runs "git show-ref"
+	// which returns error if the revision does not correspond to a tag or head.  If we receive an error,
+	// it might be because the local repository is behind the remote, so don't error immediately.
+	err = repo.vcs.run(importDir, repo.vcs.tagSyncCmd, "tag", expectedRevision)
+	if err == nil {
+		return
+	}
+
 	// If we didn't just get this package, download it now to update.
 	if maybeGot == "" {
 		err = repo.vcs.download(importDir)
@@ -200,8 +208,9 @@ func syncPkg(ch chan<- string, importPath, expectedRevision, getOutput string, g
 		}
 	}
 
-	// Checkout the expected revision.  Don't use tagSync because it runs "git show-ref"
-	// which returns error if the revision does not correspond to a tag or head.
+	// Checkout the expected revision, which is expected to be there now that we're up-to-date with the remote.
+	// Don't use tagSync because it runs "git show-ref" which returns error if the revision does not correspond to a
+	// tag or head.
 	err = repo.vcs.run(importDir, repo.vcs.tagSyncCmd, "tag", expectedRevision)
 	if err != nil {
 		perror(err)


### PR DESCRIPTION
… operation in case we already have the desired revision locally