### PR TITLE
Updated downloadCmd for git to also fetch tags.

### DIFF
--- a/vcs.go
+++ b/vcs.go
@@ -94,7 +94,7 @@ var vcsGit = &vcsCmd{
 	cmd:  "git",
 
 	createCmd:   "clone {repo} {dir}",
-	downloadCmd: "pull --ff-only",
+	downloadCmd: "pull --ff-only --tags",
 
 	tagCmd: []tagCmd{
 		// tags/xxx matches a git tag named xxx


### PR DESCRIPTION
git pull --ff-only does not pull all tags. It will only pull tags
where the ref exists on the master branch. Because of this, glock sync
will fail if the ref only exists on a tag that doesn't exists locally.

Without this change, if a user pins to a ref that only exists on tag
that doesn't exists locally, they will either need to run git fetch --tags
or delete the repo and have glock downlaod the repo again.

All this change does is modify the download command to also pull tags in
order to avoid the scenario above.

#45 