### PR TITLE
Have sync create module major-release symlinks

### DIFF
--- a/glock.go
+++ b/glock.go
@@ -9,7 +9,9 @@ import (
 	"text/template"
 )
 
-var buildV bool // Used in vcs.go and http.go to print detailed stuff about go get
+// Used in vcs.go and http.go to print detailed stuff about go get.
+// Also used to enable output from the debug() function declared in util.go.
+var buildV bool
 
 type Command struct {
 	Run       func(cmd *Command, args []string)

--- a/util.go
+++ b/util.go
@@ -141,3 +141,30 @@ func glockfileWriter(importPath string, n bool) io.WriteCloser {
 	}
 	return f
 }
+
+// sameFile returns true if path1 and path2 refer to the same file. If either
+// are symlinks, then the comparison is done after the links are followed.
+func sameFile(path1, path2 string) (bool, error) {
+		info1, err := os.Stat(path1)
+		if os.IsNotExist(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+
+		info2, err := os.Stat(path2)
+		if os.IsNotExist(err) {
+			return false, nil
+		} else if err != nil {
+			return false, err
+		}
+
+		return os.SameFile(info1, info2), nil
+}
+
+// debug prints args to STDERR if in verbose mode.
+func debug(args ...interface{}) {
+	if buildV {
+		fmt.Fprintln(os.Stderr, args...)
+	}
+}

--- a/vcs.go
+++ b/vcs.go
@@ -104,8 +104,8 @@ var vcsGit = &vcsCmd{
 	tagLookupCmd: []tagCmd{
 		{"show-ref tags/{tag} origin/{tag}", `((?:tags|origin)/\S+)$`},
 	},
-	tagSyncCmd:     "checkout {tag}",
-	tagSyncDefault: "checkout master",
+	tagSyncCmd:     "checkout -f {tag} --",
+	tagSyncDefault: "checkout -f master --",
 
 	scheme:  []string{"git", "https", "http", "git+ssh"},
 	pingCmd: "ls-remote {scheme}://{repo}",


### PR DESCRIPTION
When a module containing a go.mod is synced, the module name may contain
a major release suffix (e.g. "rsc.io/quote/v2"), indicating that the
code at the module root is a post-v1 major release and that users of the
module should import it with this suffix. Prior to this change, code
using such a module would have had to import it without the suffix,
requiring different versions of the client code to exist in order to
be buildable in both module-aware and legacy-GOPATH modes.

This change creates a self-referencing major-release symlink if the
imported module contains a go.mod specifying a major release suffix.
This allows both legacy-GOPATH and module-aware builds to succeed,
which can help users migrating from glock to Go modules avoid a hard
cutover due to import path incompatibilities.

Because glock now changes the contents in GOPATH/src/... from the
checked-out source, the git tagSyncCmd was updated with a -f flag, in
order to force checkout and overwrite any created symlinks that might
conflict with to-be-checked-out content.